### PR TITLE
removed unnecessary ctx.getContextPath at QuartzConfigurator

### DIFF
--- a/src/main/java/br/com/caelum/vraptor/quartzjob/QuartzConfigurator.java
+++ b/src/main/java/br/com/caelum/vraptor/quartzjob/QuartzConfigurator.java
@@ -4,7 +4,6 @@ import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.event.Observes;
 import javax.inject.Inject;
-import javax.servlet.ServletContext;
 
 import br.com.caelum.vraptor.events.VRaptorInitialized;
 import org.apache.commons.httpclient.HttpClient;
@@ -27,15 +26,13 @@ public class QuartzConfigurator {
 
 	private final static Logger logger = LoggerFactory.getLogger(QuartzConfigurator.class);
 	private Environment env;
-	private ServletContext ctx;
 
 	@Deprecated // CDI eyes only
 	public QuartzConfigurator() {}
 
 	@Inject
-	public QuartzConfigurator(Environment env, ServletContext ctx) throws SchedulerException {
+	public QuartzConfigurator(Environment env) throws SchedulerException {
 		this.env = env;
-		this.ctx = ctx;
 	}
 
 	public void initialize(@Observes VRaptorInitialized event) {
@@ -48,7 +45,7 @@ public class QuartzConfigurator {
 			logger.info("Quartz configurator initializing...");
 			scheduler = StdSchedulerFactory.getDefaultScheduler();
 
-			String url = (env.get("host") + ctx.getContextPath() + "/jobs/configure")
+			String url = (env.get("host") + "/jobs/configure")
 					.replace("https", "http");
 
 			Runnable quartzMe = new StartQuartz(url);


### PR DESCRIPTION
refers to #15 

QuartzConfigurator.initialize wrongly assumes that the host environment var (who should points to the service full url) doesn't have the contextPath in it

